### PR TITLE
Parse game_comments and game_type into airdates table

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -27,7 +27,9 @@ def main(args):
         sql.execute("""PRAGMA foreign_keys = ON;""")
         sql.execute("""CREATE TABLE airdates(
             game INTEGER PRIMARY KEY,
-            airdate TEXT
+            airdate TEXT,
+            game_comments TEXT,
+            game_type TEXT
         );""")
         sql.execute("""CREATE TABLE documents(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -66,7 +68,30 @@ def parse_game(f, sql, gid):
     # The title is in the format: `J! Archive - Show #XXXX, aired 2004-09-16`,
     # where the last part is all that is required
     airdate = bsoup.title.get_text().split()[-1]
-    if not parse_round(bsoup, sql, 1, gid, airdate) or not parse_round(bsoup, sql, 2, gid, airdate):
+    
+    game_comments = bsoup.find("div", id="game_comments")
+    game_comments = game_comments.get_text() if game_comments else ""
+    if "Teen Tournament" in game_comments:
+        game_type = "teen_tournament"
+    elif "Battle of the Decades" in game_comments:
+        game_type = "battle_of_the_decades"
+    elif "Tournament of Champions" in game_comments:
+        game_type = "tournament_of_champions"
+    elif "College Championship" in game_comments:
+        game_type = "college_championship"
+    elif "Teachers Tournament" in game_comments:
+        game_type = "teachers_tournament"
+    elif "Kids Week" in game_comments:
+        game_type = "kids_week"
+    elif "Power Players Week" in game_comments:
+        game_type = "power_players_week"
+    elif "The IBM Challenge" in game_comments:
+        game_type = "ibm_challenge"
+    elif "Million Dollar Celebrity Invitational" in game_comments:
+        game_type = "million_dollar_celebrity_invitational"
+    else:
+        game_type = "normal"
+    if not parse_round(bsoup, sql, 1, gid, airdate, game_comments, game_type) or not parse_round(bsoup, sql, 2, gid, airdate, game_comments, game_type):
         # One of the rounds does not exist
         pass
     # The final Jeopardy! round
@@ -79,10 +104,11 @@ def parse_game(f, sql, gid):
     answer = BeautifulSoup(r.find("div", onmouseover=True).get("onmouseover"), "lxml")
     answer = answer.find("em").get_text()
     # False indicates no preset value for a clue
-    insert(sql, [gid, airdate, 3, category, False, text, answer])
+    insert(sql, [gid, airdate, game_comments, game_type, 3, category, False, text, answer])
 
 
-def parse_round(bsoup, sql, rnd, gid, airdate):
+
+def parse_round(bsoup, sql, rnd, gid, airdate, game_comments, game_type):
     """Parses and inserts the list of clues from a whole round."""
     round_id = "jeopardy_round" if rnd == 1 else "double_jeopardy_round"
     r = bsoup.find(id=round_id)
@@ -102,7 +128,7 @@ def parse_round(bsoup, sql, rnd, gid, airdate):
             text = a.find("td", class_="clue_text").get_text()
             answer = BeautifulSoup(a.find("div", onmouseover=True).get("onmouseover"), "lxml")
             answer = answer.find("em", class_="correct_response").get_text()
-            insert(sql, [gid, airdate, rnd, categories[x], value, text, answer])
+            insert(sql, [gid, airdate, game_comments, game_type, rnd, categories[x], value, text, answer])
         # Always update x, even if we skip
         # a clue, as this keeps things in order. there
         # are 6 categories, so once we reach the end,
@@ -119,23 +145,23 @@ def parse_round(bsoup, sql, rnd, gid, airdate):
 
 def insert(sql, clue):
     """Inserts the given clue into the database."""
-    # Clue is [game, airdate, round, category, value, clue, answer]
+    # Clue is [game, airdate, game_comments, game_type, round, category, value, clue, answer]
     # Note that at this point, clue[4] is False if round is 3
-    if "\\\'" in clue[6]:
-        clue[6] = clue[6].replace("\\\'", "'")
-    if "\\\"" in clue[6]:
-        clue[6] = clue[6].replace("\\\"", "\"")
+    if "\\\'" in clue[8]:
+        clue[6] = clue[8].replace("\\\'", "'")
+    if "\\\"" in clue[8]:
+        clue[6] = clue[8].replace("\\\"", "\"")
     if not sql:
         print clue
         return
     sql.execute(
-        "INSERT OR IGNORE INTO airdates VALUES(?, ?);",
-        (clue[0], clue[1], )
+        "INSERT OR IGNORE INTO airdates VALUES(?, ?, ?, ?);",
+        (clue[0], clue[1], clue[2], clue[3])
     )
-    sql.execute("INSERT OR IGNORE INTO categories(category) VALUES(?);", (clue[3], ))
-    category_id = sql.execute("SELECT id FROM categories WHERE category=?;", (clue[3], )).fetchone()[0]
-    clue_id = sql.execute("INSERT INTO documents(clue, answer) VALUES(?, ?);", (clue[5], clue[6], )).lastrowid
-    sql.execute("INSERT INTO clues(game, round, value) VALUES(?, ?, ?);", (clue[0], clue[2], clue[4], ))
+    sql.execute("INSERT OR IGNORE INTO categories(category) VALUES(?);", (clue[5], ))
+    category_id = sql.execute("SELECT id FROM categories WHERE category=?;", (clue[5], )).fetchone()[0]
+    clue_id = sql.execute("INSERT INTO documents(clue, answer) VALUES(?, ?);", (clue[7], clue[8], )).lastrowid
+    sql.execute("INSERT INTO clues(game, round, value) VALUES(?, ?, ?);", (clue[0], clue[4], clue[6], ))
     sql.execute("INSERT INTO classifications VALUES(?, ?)", (clue_id, category_id, ))
 
 


### PR DESCRIPTION
I added two columns, `game_comments` and `game_type`, to the `airdates` table, and I'm parsing both from the web pages. `game_comments` is a string that contains things like "Ken Jennings game 12." or "2008-A Teen Tournament quarterfinal game 2." I use that string to populate `game_type`, which is a normalized set of game types I came up with by looking through all the game comments, like "college_championship" and "teen_tournament". Before this pull request, there was no way to query the database for games of a certain type, which can be very useful.